### PR TITLE
Omada Controller Version - Case Sensitivity Fix and Filename Display

### DIFF
--- a/install-omada-controller.sh
+++ b/install-omada-controller.sh
@@ -51,7 +51,7 @@ echo "[+] Installing JSVC"
 apt-get -qq install jsvc &> /dev/null
 
 echo "[+] Downloading the latest Omada Software Controller package"
-OmadaPackageUrl=$(curl -fsSL https://www.tp-link.com/us/support/download/omada-software-controller/ | grep -oP '<a[^>]*href="\K[^"]*Linux_x64.deb[^"]*' | head -n 1)
+OmadaPackageUrl=$(curl -fsSL https://www.tp-link.com/us/support/download/omada-software-controller/ | grep -oPi '<a[^>]*href="\K[^"]*Linux_x64.deb[^"]*' | head -n 1)
 wget -qP /tmp/ $OmadaPackageUrl
 echo "[+] Installing Omada Software Controller"
 dpkg -i /tmp/$(basename $OmadaPackageUrl) &> /dev/null

--- a/install-omada-controller.sh
+++ b/install-omada-controller.sh
@@ -4,7 +4,7 @@
 #supported       :Ubuntu 16.04, Ubuntu 18.04, Ubuntu 20.04, Ubuntu 22.04
 #author          :monsn0
 #date            :2021-07-29
-#updated         :2023-11-19
+#updated         :2024-01-17
 
 echo -e "\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 echo "TP-Link Omada Software Controller - Installer"
@@ -53,7 +53,7 @@ apt-get -qq install jsvc &> /dev/null
 echo "[+] Downloading the latest Omada Software Controller package"
 OmadaPackageUrl=$(curl -fsSL https://www.tp-link.com/us/support/download/omada-software-controller/ | grep -oPi '<a[^>]*href="\K[^"]*Linux_x64.deb[^"]*' | head -n 1)
 wget -qP /tmp/ $OmadaPackageUrl
-echo "[+] Installing Omada Software Controller"
+echo "[+] Installing $(basename $OmadaPackageUrl)"
 dpkg -i /tmp/$(basename $OmadaPackageUrl) &> /dev/null
 
 hostIP=$(hostname -I | cut -f1 -d' ')

--- a/install-omada-controller.sh
+++ b/install-omada-controller.sh
@@ -4,7 +4,7 @@
 #supported       :Ubuntu 16.04, Ubuntu 18.04, Ubuntu 20.04, Ubuntu 22.04
 #author          :monsn0
 #date            :2021-07-29
-#updated         :2024-01-17
+#updated         :2023-11-19
 
 echo -e "\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 echo "TP-Link Omada Software Controller - Installer"
@@ -53,7 +53,7 @@ apt-get -qq install jsvc &> /dev/null
 echo "[+] Downloading the latest Omada Software Controller package"
 OmadaPackageUrl=$(curl -fsSL https://www.tp-link.com/us/support/download/omada-software-controller/ | grep -oPi '<a[^>]*href="\K[^"]*Linux_x64.deb[^"]*' | head -n 1)
 wget -qP /tmp/ $OmadaPackageUrl
-echo "[+] Installing $(basename $OmadaPackageUrl)"
+echo "[+] Installing Omada Software Controller $(echo $(basename $OmadaPackageUrl) | tr "_" "\n" | sed -n '4p')"
 dpkg -i /tmp/$(basename $OmadaPackageUrl) &> /dev/null
 
 hostIP=$(hostname -I | cut -f1 -d' ')


### PR DESCRIPTION
Started to mess around with trying to get Debian installation to work in a testing branch on my fork and found that it was installing one version behind.
The culprit was the case of L on Linux in the file name.
I also changed the output to show the filename at that point so it's more apparent which version is being installed.