### PR TITLE
Install wget

### DIFF
--- a/install-omada-controller.sh
+++ b/install-omada-controller.sh
@@ -38,7 +38,7 @@ fi
 
 echo "[+] Installing script prerequisites"
 apt-get -qq update
-apt-get -qq install gnupg curl &> /dev/null
+apt-get -qq install gnupg curl wget &> /dev/null
 
 echo "[+] Importing the MongoDB 7.0 PGP key and creating the APT repository"
 curl -fsSL https://www.mongodb.org/static/pgp/server-7.0.asc | gpg -o /usr/share/keyrings/mongodb-server-7.0.gpg --dearmor


### PR DESCRIPTION
On the LXD container images, wget is not installed by default. It causes the script to say it was successful, but omada is not installed.